### PR TITLE
ci: add GoReleaser workflow for automated releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,32 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Changes

Adds a new GitHub Actions workflow that runs GoReleaser on version tags (`v*`).

- Builds binaries for **Linux, macOS, Windows** (amd64, arm64, i386)
- Publishes **GitHub Releases** automatically with changelogs and checksums
- Uses existing `.goreleaser.yaml` config
- Triggered only on tag push (`v*`), doesn't affect regular CI

### Usage
```bash
git tag v1.0.0
git push origin v1.0.0
```

Actions used:
- `actions/checkout@v6`
- `actions/setup-go@v6`
- `goreleaser/goreleaser-action@v6`